### PR TITLE
Dependency injection module for instrumentation tests

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,7 @@ android {
         versionCode 2
         versionName "1.1"
 
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "ar.edu.unq.pdes.myprivateblog.TestApplicationRunner"
 
         // The following argument makes the Android Test Orchestrator run its
         // "pm clear" command after each test invocation. This command ensures
@@ -134,6 +134,7 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-web:3.2.0'
     androidTestUtil 'androidx.test:orchestrator:1.3.0-alpha05'
     kaptAndroidTest "com.google.dagger:dagger-compiler:$daggerVersion"
+    kaptAndroidTest "com.google.dagger:dagger-android-processor:$daggerVersion"
 
     implementation 'com.google.firebase:firebase-analytics:17.4.1'
     implementation 'com.google.firebase:firebase-crashlytics:17.0.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,7 +17,7 @@ android {
         versionCode 2
         versionName "1.1"
 
-        testInstrumentationRunner "ar.edu.unq.pdes.myprivateblog.TestApplicationRunner"
+        testInstrumentationRunner "ar.edu.unq.pdes.myprivateblog.instrumentation.TestApplicationRunner"
 
         // The following argument makes the Android Test Orchestrator run its
         // "pm clear" command after each test invocation. This command ensures

--- a/app/src/androidTest/java/ar/edu/unq/pdes/myprivateblog/PostsListingTest.kt
+++ b/app/src/androidTest/java/ar/edu/unq/pdes/myprivateblog/PostsListingTest.kt
@@ -19,13 +19,6 @@ class PostsListingTest {
     var activityRule: ActivityScenarioRule<MainActivity> =
         ActivityScenarioRule(MainActivity::class.java)
 
-//    @Before
-//    fun setUp() {
-//        val testingComponent: ApplicationComponent = DaggerApplicationComponent.builder()
-//            .authModule(FakeAuthModule())
-//            .build()
-//    }
-
     @Test
     fun whenTappingOnNewPost_postCreationScreenShouldOpen() {
         goToCreatePost()

--- a/app/src/androidTest/java/ar/edu/unq/pdes/myprivateblog/instrumentation/TestApplication.kt
+++ b/app/src/androidTest/java/ar/edu/unq/pdes/myprivateblog/instrumentation/TestApplication.kt
@@ -2,6 +2,7 @@ package ar.edu.unq.pdes.myprivateblog.instrumentation
 
 import ar.edu.unq.pdes.myprivateblog.BaseApplication
 import ar.edu.unq.pdes.myprivateblog.BuildConfig
+import ar.edu.unq.pdes.myprivateblog.DaggerTestApplicationComponent
 import ar.edu.unq.pdes.myprivateblog.di.DaggerApplicationComponent
 import timber.log.Timber
 
@@ -9,7 +10,7 @@ class TestApplication : BaseApplication() {
     override fun onCreate() {
         super.onCreate()
 
-        DaggerApplicationComponent.factory()
+        DaggerTestApplicationComponent.factory()
             .create(applicationContext)
             .inject(this)
 

--- a/app/src/androidTest/java/ar/edu/unq/pdes/myprivateblog/instrumentation/TestApplication.kt
+++ b/app/src/androidTest/java/ar/edu/unq/pdes/myprivateblog/instrumentation/TestApplication.kt
@@ -2,8 +2,6 @@ package ar.edu.unq.pdes.myprivateblog.instrumentation
 
 import ar.edu.unq.pdes.myprivateblog.BaseApplication
 import ar.edu.unq.pdes.myprivateblog.BuildConfig
-import ar.edu.unq.pdes.myprivateblog.DaggerTestApplicationComponent
-import ar.edu.unq.pdes.myprivateblog.di.DaggerApplicationComponent
 import timber.log.Timber
 
 class TestApplication : BaseApplication() {

--- a/app/src/androidTest/java/ar/edu/unq/pdes/myprivateblog/instrumentation/TestApplication.kt
+++ b/app/src/androidTest/java/ar/edu/unq/pdes/myprivateblog/instrumentation/TestApplication.kt
@@ -1,0 +1,18 @@
+package ar.edu.unq.pdes.myprivateblog.instrumentation
+
+import ar.edu.unq.pdes.myprivateblog.BaseApplication
+import ar.edu.unq.pdes.myprivateblog.BuildConfig
+import ar.edu.unq.pdes.myprivateblog.di.DaggerApplicationComponent
+import timber.log.Timber
+
+class TestApplication : BaseApplication() {
+    override fun onCreate() {
+        super.onCreate()
+
+        DaggerApplicationComponent.factory()
+            .create(applicationContext)
+            .inject(this)
+
+        if (BuildConfig.DEBUG) Timber.plant(Timber.DebugTree())
+    }
+}

--- a/app/src/androidTest/java/ar/edu/unq/pdes/myprivateblog/instrumentation/TestApplicationComponent.kt
+++ b/app/src/androidTest/java/ar/edu/unq/pdes/myprivateblog/instrumentation/TestApplicationComponent.kt
@@ -1,0 +1,42 @@
+package ar.edu.unq.pdes.myprivateblog.instrumentation
+
+import android.content.Context
+import ar.edu.unq.pdes.myprivateblog.BaseApplication
+import ar.edu.unq.pdes.myprivateblog.di.*
+import ar.edu.unq.pdes.myprivateblog.services.AuthService
+import ar.edu.unq.pdes.myprivateblog.services.FakeAuthService
+import dagger.BindsInstance
+import dagger.Component
+import dagger.Module
+import dagger.Provides
+import dagger.android.AndroidInjector
+import dagger.android.support.AndroidSupportInjectionModule
+import javax.inject.Singleton
+
+@Singleton
+@Component(
+    modules = [
+        AndroidSupportInjectionModule::class,
+        ApplicationModule::class,
+        MainActivityModule::class,
+        LoggerModule::class,
+        FakeAuthModule::class
+    ]
+)
+interface TestApplicationComponent : AndroidInjector<BaseApplication> {
+
+    @Component.Factory
+    interface Factory {
+        fun create(@BindsInstance applicationContext: Context): TestApplicationComponent
+    }
+}
+
+@Module
+open class FakeAuthModule {
+
+    @Singleton
+    @Provides
+    open fun provideAuthService(): AuthService {
+        return FakeAuthService()
+    }
+}

--- a/app/src/androidTest/java/ar/edu/unq/pdes/myprivateblog/instrumentation/TestApplicationRunner.kt
+++ b/app/src/androidTest/java/ar/edu/unq/pdes/myprivateblog/instrumentation/TestApplicationRunner.kt
@@ -1,0 +1,10 @@
+package ar.edu.unq.pdes.myprivateblog.instrumentation
+
+import android.app.Instrumentation
+import android.content.Context
+import androidx.test.runner.AndroidJUnitRunner
+
+class TestApplicationRunner: AndroidJUnitRunner() {
+    override fun newApplication(cl: ClassLoader?, className: String?, context: Context?)
+            = Instrumentation.newApplication(TestApplication::class.java, context)
+}

--- a/app/src/main/java/ar/edu/unq/pdes/myprivateblog/BaseApplication.kt
+++ b/app/src/main/java/ar/edu/unq/pdes/myprivateblog/BaseApplication.kt
@@ -8,7 +8,7 @@ import dagger.android.HasAndroidInjector
 import timber.log.Timber
 import javax.inject.Inject
 
-class BaseApplication : Application(), HasAndroidInjector {
+open class BaseApplication : Application(), HasAndroidInjector {
 
     @Inject
     @JvmField

--- a/app/src/main/java/ar/edu/unq/pdes/myprivateblog/di/ApplicationComponent.kt
+++ b/app/src/main/java/ar/edu/unq/pdes/myprivateblog/di/ApplicationComponent.kt
@@ -20,6 +20,7 @@ import ar.edu.unq.pdes.myprivateblog.screens.post_edit.PostEditViewModel
 import ar.edu.unq.pdes.myprivateblog.screens.posts_listing.PostsListingFragment
 import ar.edu.unq.pdes.myprivateblog.screens.posts_listing.PostsListingViewModel
 import ar.edu.unq.pdes.myprivateblog.services.AuthService
+import ar.edu.unq.pdes.myprivateblog.services.FakeAuthService
 import ar.edu.unq.pdes.myprivateblog.services.FirebaseAuthService
 import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
@@ -48,11 +49,6 @@ interface ApplicationComponent : AndroidInjector<BaseApplication> {
     }
 }
 
-//@Singleton
-//@Component(modules = [FakeAuthModule::class])
-//interface TestComponent : ApplicationComponent {
-//}
-
 @Module
 open class ApplicationModule {
 
@@ -77,6 +73,7 @@ open class ApplicationModule {
         return BlogEntriesRepository(appDatabase.blogEntriesDao(), remoteRepository)
     }
 }
+
 
 @Module(
     includes = [
@@ -161,20 +158,10 @@ open class AuthModule {
 
     @Singleton
     @Provides
-    fun provideAuthService(context: Context): AuthService {
+    open fun provideAuthService(context: Context): AuthService {
         return FirebaseAuthService(context)
     }
 }
-
-//@Module
-//open class FakeAuthModule {
-//
-//    @Singleton
-//    @Provides
-//    fun provideAuthService(context: Context): AuthService {
-//        return FakeAuthService()
-//    }
-//}
 
 @Module
 abstract class LoginModule {


### PR DESCRIPTION
Esta es una manera de configurar un componente de dagger2 específico para los tests.
En general para tests de UI no se van a ir cambiando mucho las dependencias fake porque la idea es que sea lo más parecido a producción posible, así que con esto debería alcanzar.